### PR TITLE
Make Item Filler work with Bocks that only have meta when placed in world.

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemFillingWand.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemFillingWand.java
@@ -201,7 +201,7 @@ public class ItemFillingWand extends ItemEnergy{
 
     private static boolean removeFittingItem(IBlockState state, EntityPlayer player){
         Block block = state.getBlock();
-        ItemStack stack = new ItemStack(block, 1, block.damageDropped(state));
+        ItemStack stack = new ItemStack(block, 1, block.getMetaFromState(state));
 
         if(stack != null && stack.getItem() != null){
             for(int i = 0; i < player.inventory.getSizeInventory(); i++){

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemFillingWand.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemFillingWand.java
@@ -201,7 +201,7 @@ public class ItemFillingWand extends ItemEnergy{
 
     private static boolean removeFittingItem(IBlockState state, EntityPlayer player){
         Block block = state.getBlock();
-        ItemStack stack = new ItemStack(block, 1, block.getMetaFromState(state));
+        ItemStack stack = new ItemStack(block, 1, block.damageDropped(state));
 
         if(stack != null && stack.getItem() != null){
             for(int i = 0; i < player.inventory.getSizeInventory(); i++){

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/tile/TileEntityLaserRelay.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/tile/TileEntityLaserRelay.java
@@ -13,23 +13,11 @@ package de.ellpeck.actuallyadditions.mod.tile;
 import de.ellpeck.actuallyadditions.api.ActuallyAdditionsAPI;
 import de.ellpeck.actuallyadditions.api.laser.IConnectionPair;
 import de.ellpeck.actuallyadditions.api.laser.LaserType;
-import de.ellpeck.actuallyadditions.api.laser.Network;
-import de.ellpeck.actuallyadditions.mod.config.values.ConfigBoolValues;
-import de.ellpeck.actuallyadditions.mod.data.PlayerData;
-import de.ellpeck.actuallyadditions.mod.items.ItemLaserWrench;
-import de.ellpeck.actuallyadditions.mod.items.ItemLaserWrench.WrenchMode;
 import de.ellpeck.actuallyadditions.mod.misc.ConnectionPair;
-import de.ellpeck.actuallyadditions.mod.util.AssetUtil;
-import de.ellpeck.actuallyadditions.mod.util.Util;
 import io.netty.util.internal.ConcurrentSet;
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.Set;
 

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/tile/TileEntityLaserRelay.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/tile/TileEntityLaserRelay.java
@@ -13,11 +13,23 @@ package de.ellpeck.actuallyadditions.mod.tile;
 import de.ellpeck.actuallyadditions.api.ActuallyAdditionsAPI;
 import de.ellpeck.actuallyadditions.api.laser.IConnectionPair;
 import de.ellpeck.actuallyadditions.api.laser.LaserType;
+import de.ellpeck.actuallyadditions.api.laser.Network;
+import de.ellpeck.actuallyadditions.mod.config.values.ConfigBoolValues;
+import de.ellpeck.actuallyadditions.mod.data.PlayerData;
+import de.ellpeck.actuallyadditions.mod.items.ItemLaserWrench;
+import de.ellpeck.actuallyadditions.mod.items.ItemLaserWrench.WrenchMode;
 import de.ellpeck.actuallyadditions.mod.misc.ConnectionPair;
+import de.ellpeck.actuallyadditions.mod.util.AssetUtil;
+import de.ellpeck.actuallyadditions.mod.util.Util;
 import io.netty.util.internal.ConcurrentSet;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.Set;
 


### PR DESCRIPTION
I found a pretty easy fix for #330 wich I included here.