### PR TITLE
Make the Teleportation Staff use Vanilla Cooldown rather than own one

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemTeleStaff.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemTeleStaff.java
@@ -12,13 +12,11 @@ package de.ellpeck.actuallyadditions.mod.items;
 
 import de.ellpeck.actuallyadditions.mod.items.base.ItemEnergy;
 import de.ellpeck.actuallyadditions.mod.util.WorldUtil;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
@@ -33,30 +31,27 @@ public class ItemTeleStaff extends ItemEnergy{
         super(500000, 10000, name);
     }
 
-
     @Override
     public ActionResult<ItemStack> onItemRightClick(ItemStack stack, World world, EntityPlayer player, EnumHand hand){
         if(!world.isRemote){
-            if(this.getWaitTime(stack) <= 0){
-                RayTraceResult pos = WorldUtil.getNearestPositionWithAir(world, player, 100);
-                if(pos != null && (pos.typeOfHit == RayTraceResult.Type.BLOCK || player.rotationPitch >= -5)){
-                    int side = pos.sideHit.ordinal();
-                    if(side != -1){
-                        double x = pos.hitVec.xCoord-(side == 4 ? 0.5 : 0)+(side == 5 ? 0.5 : 0);
-                        double y = pos.hitVec.yCoord-(side == 0 ? 2.0 : 0)+(side == 1 ? 0.5 : 0);
-                        double z = pos.hitVec.zCoord-(side == 2 ? 0.5 : 0)+(side == 3 ? 0.5 : 0);
-                        int baseUse = 200;
-                        int use = baseUse+(int)(baseUse*pos.hitVec.distanceTo(new Vec3d(player.posX, player.posY+(player.getEyeHeight()-player.getDefaultEyeHeight()), player.posZ)));
-                        if(this.getEnergyStored(stack) >= use){
-                            ((EntityPlayerMP)player).connection.setPlayerLocation(x, y, z, player.rotationYaw, player.rotationPitch);
-                            player.dismountRidingEntity();
-                            world.playSound(null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ENDERMEN_TELEPORT, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                            if(!player.capabilities.isCreativeMode){
-                                this.extractEnergy(stack, use, false);
-                                this.setWaitTime(stack, 50);
-                            }
-                            return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+            RayTraceResult pos = WorldUtil.getNearestPositionWithAir(world, player, 100);
+            if(pos != null && (pos.typeOfHit == RayTraceResult.Type.BLOCK || player.rotationPitch >= -5)){
+                int side = pos.sideHit.ordinal();
+                if(side != -1){
+                    double x = pos.hitVec.xCoord-(side == 4 ? 0.5 : 0)+(side == 5 ? 0.5 : 0);
+                    double y = pos.hitVec.yCoord-(side == 0 ? 2.0 : 0)+(side == 1 ? 0.5 : 0);
+                    double z = pos.hitVec.zCoord-(side == 2 ? 0.5 : 0)+(side == 3 ? 0.5 : 0);
+                    int baseUse = 200;
+                    int use = baseUse+(int)(baseUse*pos.hitVec.distanceTo(new Vec3d(player.posX, player.posY+(player.getEyeHeight()-player.getDefaultEyeHeight()), player.posZ)));
+                    if(this.getEnergyStored(stack) >= use){
+                        ((EntityPlayerMP)player).connection.setPlayerLocation(x, y, z, player.rotationYaw, player.rotationPitch);
+                        player.dismountRidingEntity();
+                        world.playSound(null, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ENDERMEN_TELEPORT, SoundCategory.PLAYERS, 1.0F, 1.0F);
+                        if(!player.capabilities.isCreativeMode){
+                            this.extractEnergy(stack, use, false);
+                            player.getCooldownTracker().setCooldown(this, 50);
                         }
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                     }
                 }
             }
@@ -66,37 +61,7 @@ public class ItemTeleStaff extends ItemEnergy{
     }
 
     @Override
-    public void onUpdate(ItemStack stack, World world, Entity entity, int par4, boolean par5){
-        int time = this.getWaitTime(stack);
-        if(time > 0){
-            this.setWaitTime(stack, time-1);
-        }
-    }
-
-
-    @Override
     public EnumRarity getRarity(ItemStack stack){
         return EnumRarity.EPIC;
-    }
-
-    private int getWaitTime(ItemStack stack){
-        NBTTagCompound compound = stack.getTagCompound();
-        if(compound == null){
-            return 0;
-        }
-        else{
-            return compound.getInteger("waitTime");
-        }
-    }
-
-    private void setWaitTime(ItemStack stack, int time){
-        NBTTagCompound compound = stack.getTagCompound();
-        if(compound == null){
-            compound = new NBTTagCompound();
-        }
-
-        compound.setInteger("waitTime", time);
-
-        stack.setTagCompound(compound);
     }
 }


### PR DESCRIPTION
Vanilla Cooldown adds a nice little bar to the item wich is an easy understandable notification to the user. So why reinvent the Cooldown?

Changes:
* Replaced own Cooldown System with the vanilla one
* Deleted Methods used to set/get the cooldown
* Removed Imports that became useless.
* The Huge Block being readded according to the diff is only to make indentation clear