### PR TITLE
backport traveller's sack item count tooltip to 1.10.2 branch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+gradle -Pbuildnumber=bag-tooltip build

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#! /bin/sh
-gradle -Pbuildnumber=bag-tooltip build

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemBag.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/items/ItemBag.java
@@ -56,7 +56,22 @@ public class ItemBag extends ItemBase{
 
     @Override
     public void addInformation(ItemStack stack, EntityPlayer playerIn, List<String> tooltip, boolean advanced){
-        tooltip.add(TextFormatting.ITALIC+StringUtil.localize("tooltip."+ModUtil.MOD_ID+".previously"+(this.isVoid ? "VoidBag" : "Bag")));
+        ItemStack[] slots = new ItemStack[ContainerBag.getSlotAmount(this.isVoid)];
+        ItemDrill.loadSlotsFromNBT(slots, stack);
+
+        int slotsTotal = slots.length;
+        int slotsFilled = 0;
+
+        for(ItemStack slotStack : slots){
+            if(StackUtil.isValid(slotStack)){
+                slotsFilled++;
+            }
+        }
+        
+        // don't count the filter 4 slots 
+        slotsTotal = slotsTotal - 4;
+
+        tooltip.add(TextFormatting.ITALIC.toString()+slotsFilled+"/"+slotsTotal+" filled slots");
     }
 
     @SubscribeEvent


### PR DESCRIPTION
I have port the changes for #407 to 1.10.2, working well for me

It's up to you to accept it or not. 