### PR TITLE
Add Crafting Tweaks compatibility to Crafting Table on a Stick

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/ActuallyAdditions.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/ActuallyAdditions.java
@@ -46,6 +46,7 @@ import de.ellpeck.actuallyadditions.mod.tile.TileEntityBase;
 import de.ellpeck.actuallyadditions.mod.update.UpdateChecker;
 import de.ellpeck.actuallyadditions.mod.util.ItemUtil;
 import de.ellpeck.actuallyadditions.mod.util.ModUtil;
+import de.ellpeck.actuallyadditions.mod.util.compat.CraftingTweaksCompat;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -115,6 +116,8 @@ public class ActuallyAdditions{
         new CommonEvents();
         InitCrafting.init();
         InitEntities.init();
+
+        CraftingTweaksCompat.register();
 
         proxy.init(event);
 

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/util/compat/CraftingTweaksCompat.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/util/compat/CraftingTweaksCompat.java
@@ -1,0 +1,18 @@
+package de.ellpeck.actuallyadditions.mod.util.compat;
+
+import de.ellpeck.actuallyadditions.mod.inventory.ContainerCrafter;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+
+public class CraftingTweaksCompat{
+
+    private static final String MOD_ID = "craftingtweaks";
+
+    public static void register(){
+        NBTTagCompound tagCompound = new NBTTagCompound();
+        tagCompound.setString("ContainerClass", ContainerCrafter.class.getName());
+        tagCompound.setString("AlignToGrid", "left");
+        FMLInterModComms.sendMessage(MOD_ID, "RegisterProvider", tagCompound);
+    }
+
+}


### PR DESCRIPTION
This utilizes [Crafting Tweaks](https://minecraft.curseforge.com/projects/crafting-tweaks)' IMC API to add support for its crafting buttons (rotate/balance/spread/clear) to the "Crafting Table On A Stick".