### PR TITLE
don't return internal copy of itemstack on simulate

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/util/ItemStackHandlerCustom.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/util/ItemStackHandlerCustom.java
@@ -103,8 +103,9 @@ public class ItemStackHandlerCustom extends ItemStackHandler{
             if(!simulate){
                 this.stacks.set(slot, StackUtil.getNull());
                 this.onContentsChanged(slot);
+                return existing;
             }
-            return existing;
+            return existing.copy();
         }
         else{
             if(!simulate){


### PR DESCRIPTION
Without this you're returning the instance that's still in your list, inviting all kinds of trouble.