### PR TITLE
Added config option to disable machines from engineer house not drop when breaked.

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/config/values/ConfigBoolValues.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/config/values/ConfigBoolValues.java
@@ -17,7 +17,7 @@ public enum ConfigBoolValues{
     JAM_VILLAGER_EXISTS("Jam Villager: Existence", ConfigCategories.WORLD_GEN, true, "Should the Jam Villager and his House generate in the world?"),
     CROP_FIELD_EXISTS("Crop Field: Existence", ConfigCategories.WORLD_GEN, true, "Should Custom Crop Fields exist?"),
     ENGINEER_VILLAGER_EXISTS("Engineer Villager: Existence", ConfigCategories.WORLD_GEN, true, "Should the Engineer Villager and his House generate in the worl?"),
-
+    ENGINEER_HOUSE_MACHINES_DROP("Engineer House Machines Drop or Not", ConfigCategories.WORLD_GEN, true, "Should Machines from Engineer House drop when breaked?"),
     GENERATE_QUARTZ("Black Quartz", ConfigCategories.WORLD_GEN, true, "Shold Black Quartz generate in the world?"),
 
     DO_UPDATE_CHECK("Do Update Check", ConfigCategories.OTHER, true, "If true, Actually Additions Checks for updates on World Load."),

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
@@ -109,7 +109,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
                 TileEntity compost = this.getTileAtPos(world, 6, 1, 2, sbb);
                 if(compost instanceof TileEntityCompost){
                     TileEntityCompost tile = (TileEntityCompost)compost;
-                    tile.stopFromDropping = true;
+                    tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                     tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemFertilizer, 10));
                 }
             }
@@ -117,14 +117,14 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity ferment = this.getTileAtPos(world, 11, 1, 0, sbb);
             if(ferment instanceof TileEntityFermentingBarrel){
                 TileEntityFermentingBarrel tile = (TileEntityFermentingBarrel)ferment;
-                tile.stopFromDropping = true;
+                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.canolaTank.setFluid(new FluidStack(InitFluids.fluidCanolaOil, world.rand.nextInt(1500)+200));
             }
 
             TileEntity coffee = this.getTileAtPos(world, 4, 2, 6, sbb);
             if(coffee instanceof TileEntityCoffeeMachine){
                 TileEntityCoffeeMachine tile = (TileEntityCoffeeMachine)coffee;
-                tile.stopFromDropping = true;
+                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.tank.setFluid(new FluidStack(FluidRegistry.WATER, world.rand.nextInt(3000)+500));
                 tile.coffeeCacheAmount = world.rand.nextInt(150);
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
@@ -133,7 +133,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity press = this.getTileAtPos(world, 2, 1, 5, sbb);
             if(press instanceof TileEntityCanolaPress){
                 TileEntityCanolaPress tile = (TileEntityCanolaPress)press;
-                tile.stopFromDropping = true;
+                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/3));
                 tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemMisc, world.rand.nextInt(60)+1, TheMiscItems.CANOLA.ordinal()));
             }
@@ -141,7 +141,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity crusher = this.getTileAtPos(world, 2, 1, 6, sbb);
             if(crusher instanceof TileEntityGrinder){
                 TileEntityGrinder tile = (TileEntityGrinder)crusher;
-                tile.stopFromDropping = true;
+                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
                 if(world.rand.nextFloat() >= 0.25F){
                     tile.slots.setStackInSlot(TileEntityGrinder.SLOT_INPUT_1, new ItemStack(InitBlocks.blockMisc, world.rand.nextInt(10)+1, TheMiscBlocks.ORE_QUARTZ.ordinal()));
@@ -151,13 +151,13 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity coal = this.getTileAtPos(world, 5, 5, 6, sbb);
             if(coal instanceof TileEntityCoalGenerator){
                 TileEntityCoalGenerator tile = (TileEntityCoalGenerator)coal;
-                tile.stopFromDropping = true;
+                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.slots.setStackInSlot(0, new ItemStack(Items.COAL, world.rand.nextInt(25)+3, 1));
             }
 
             TileEntity reconstructor = this.getTileAtPos(world, 8, 4, 3, sbb);
             if(reconstructor instanceof TileEntityAtomicReconstructor){
-                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = true;
+                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
             }
 
             VillageComponentJamHouse.generateCrate(world, sbb, this.getXWithOffset(6, 4), this.getYWithOffset(4), this.getZWithOffset(6, 4), DungeonLoot.ENGINEER_HOUSE);
@@ -166,8 +166,8 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
         TileEntity firstRelay = this.getTileAtPos(world, 6, 5, 6, sbb);
         TileEntity secondRelay = this.getTileAtPos(world, 8, 5, 3, sbb);
         if(firstRelay instanceof TileEntityLaserRelayEnergy && secondRelay instanceof TileEntityLaserRelayEnergy){
-            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = true;
-            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = true;
+            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
             ActuallyAdditionsAPI.connectionHandler.addConnection(firstRelay.getPos(), secondRelay.getPos(), LaserType.ENERGY, world);
         }
 

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
@@ -109,7 +109,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
                 TileEntity compost = this.getTileAtPos(world, 6, 1, 2, sbb);
                 if(compost instanceof TileEntityCompost){
                     TileEntityCompost tile = (TileEntityCompost)compost;
-                    tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                    tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                     tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemFertilizer, 10));
                 }
             }
@@ -117,14 +117,14 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity ferment = this.getTileAtPos(world, 11, 1, 0, sbb);
             if(ferment instanceof TileEntityFermentingBarrel){
                 TileEntityFermentingBarrel tile = (TileEntityFermentingBarrel)ferment;
-                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.canolaTank.setFluid(new FluidStack(InitFluids.fluidCanolaOil, world.rand.nextInt(1500)+200));
             }
 
             TileEntity coffee = this.getTileAtPos(world, 4, 2, 6, sbb);
             if(coffee instanceof TileEntityCoffeeMachine){
                 TileEntityCoffeeMachine tile = (TileEntityCoffeeMachine)coffee;
-                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.tank.setFluid(new FluidStack(FluidRegistry.WATER, world.rand.nextInt(3000)+500));
                 tile.coffeeCacheAmount = world.rand.nextInt(150);
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
@@ -133,7 +133,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity press = this.getTileAtPos(world, 2, 1, 5, sbb);
             if(press instanceof TileEntityCanolaPress){
                 TileEntityCanolaPress tile = (TileEntityCanolaPress)press;
-                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/3));
                 tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemMisc, world.rand.nextInt(60)+1, TheMiscItems.CANOLA.ordinal()));
             }
@@ -141,7 +141,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity crusher = this.getTileAtPos(world, 2, 1, 6, sbb);
             if(crusher instanceof TileEntityGrinder){
                 TileEntityGrinder tile = (TileEntityGrinder)crusher;
-                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
                 if(world.rand.nextFloat() >= 0.25F){
                     tile.slots.setStackInSlot(TileEntityGrinder.SLOT_INPUT_1, new ItemStack(InitBlocks.blockMisc, world.rand.nextInt(10)+1, TheMiscBlocks.ORE_QUARTZ.ordinal()));
@@ -151,13 +151,13 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity coal = this.getTileAtPos(world, 5, 5, 6, sbb);
             if(coal instanceof TileEntityCoalGenerator){
                 TileEntityCoalGenerator tile = (TileEntityCoalGenerator)coal;
-                tile.stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
                 tile.slots.setStackInSlot(0, new ItemStack(Items.COAL, world.rand.nextInt(25)+3, 1));
             }
 
             TileEntity reconstructor = this.getTileAtPos(world, 8, 4, 3, sbb);
             if(reconstructor instanceof TileEntityAtomicReconstructor){
-                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
             }
 
             VillageComponentJamHouse.generateCrate(world, sbb, this.getXWithOffset(6, 4), this.getYWithOffset(4), this.getZWithOffset(6, 4), DungeonLoot.ENGINEER_HOUSE);
@@ -166,8 +166,8 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
         TileEntity firstRelay = this.getTileAtPos(world, 6, 5, 6, sbb);
         TileEntity secondRelay = this.getTileAtPos(world, 8, 5, 3, sbb);
         if(firstRelay instanceof TileEntityLaserRelayEnergy && secondRelay instanceof TileEntityLaserRelayEnergy){
-            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
-            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = If (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
             ActuallyAdditionsAPI.connectionHandler.addConnection(firstRelay.getPos(), secondRelay.getPos(), LaserType.ENERGY, world);
         }
 

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/gen/village/component/VillageComponentEngineerHouse.java
@@ -109,7 +109,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
                 TileEntity compost = this.getTileAtPos(world, 6, 1, 2, sbb);
                 if(compost instanceof TileEntityCompost){
                     TileEntityCompost tile = (TileEntityCompost)compost;
-                    tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                    tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                     tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemFertilizer, 10));
                 }
             }
@@ -117,14 +117,14 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity ferment = this.getTileAtPos(world, 11, 1, 0, sbb);
             if(ferment instanceof TileEntityFermentingBarrel){
                 TileEntityFermentingBarrel tile = (TileEntityFermentingBarrel)ferment;
-                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                 tile.canolaTank.setFluid(new FluidStack(InitFluids.fluidCanolaOil, world.rand.nextInt(1500)+200));
             }
 
             TileEntity coffee = this.getTileAtPos(world, 4, 2, 6, sbb);
             if(coffee instanceof TileEntityCoffeeMachine){
                 TileEntityCoffeeMachine tile = (TileEntityCoffeeMachine)coffee;
-                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                 tile.tank.setFluid(new FluidStack(FluidRegistry.WATER, world.rand.nextInt(3000)+500));
                 tile.coffeeCacheAmount = world.rand.nextInt(150);
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
@@ -133,7 +133,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity press = this.getTileAtPos(world, 2, 1, 5, sbb);
             if(press instanceof TileEntityCanolaPress){
                 TileEntityCanolaPress tile = (TileEntityCanolaPress)press;
-                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/3));
                 tile.slots.setStackInSlot(0, new ItemStack(InitItems.itemMisc, world.rand.nextInt(60)+1, TheMiscItems.CANOLA.ordinal()));
             }
@@ -141,7 +141,7 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity crusher = this.getTileAtPos(world, 2, 1, 6, sbb);
             if(crusher instanceof TileEntityGrinder){
                 TileEntityGrinder tile = (TileEntityGrinder)crusher;
-                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                 tile.storage.setEnergyStored(world.rand.nextInt(tile.storage.getMaxEnergyStored()/2));
                 if(world.rand.nextFloat() >= 0.25F){
                     tile.slots.setStackInSlot(TileEntityGrinder.SLOT_INPUT_1, new ItemStack(InitBlocks.blockMisc, world.rand.nextInt(10)+1, TheMiscBlocks.ORE_QUARTZ.ordinal()));
@@ -151,13 +151,13 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
             TileEntity coal = this.getTileAtPos(world, 5, 5, 6, sbb);
             if(coal instanceof TileEntityCoalGenerator){
                 TileEntityCoalGenerator tile = (TileEntityCoalGenerator)coal;
-                tile.stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                tile.stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
                 tile.slots.setStackInSlot(0, new ItemStack(Items.COAL, world.rand.nextInt(25)+3, 1));
             }
 
             TileEntity reconstructor = this.getTileAtPos(world, 8, 4, 3, sbb);
             if(reconstructor instanceof TileEntityAtomicReconstructor){
-                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+                ((TileEntityAtomicReconstructor)reconstructor).stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
             }
 
             VillageComponentJamHouse.generateCrate(world, sbb, this.getXWithOffset(6, 4), this.getYWithOffset(4), this.getZWithOffset(6, 4), DungeonLoot.ENGINEER_HOUSE);
@@ -166,8 +166,8 @@ public class VillageComponentEngineerHouse extends StructureVillagePieces.House1
         TileEntity firstRelay = this.getTileAtPos(world, 6, 5, 6, sbb);
         TileEntity secondRelay = this.getTileAtPos(world, 8, 5, 3, sbb);
         if(firstRelay instanceof TileEntityLaserRelayEnergy && secondRelay instanceof TileEntityLaserRelayEnergy){
-            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
-            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = (ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled());
+            ((TileEntityLaserRelayEnergy)firstRelay).stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
+            ((TileEntityLaserRelayEnergy)secondRelay).stopFromDropping = ConfigBoolValues.ENGINEER_HOUSE_MACHINES_DROP.isEnabled();
             ActuallyAdditionsAPI.connectionHandler.addConnection(firstRelay.getPos(), secondRelay.getPos(), LaserType.ENERGY, world);
         }
 


### PR DESCRIPTION
One thing I not like in AA is that you can not break the machines in the Engineer House because sometimes I want to move some machines but unfortunately I can't and unfortunately do not have an option to disable this in the mod config. For those as I, I've added an option to disable this. I hope you like my Addition!