### PR TITLE
Provide plant harvesting compatibility to mods that interact with blocks

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/blocks/base/BlockPlant.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/blocks/base/BlockPlant.java
@@ -16,7 +16,6 @@ import de.ellpeck.actuallyadditions.mod.util.ItemUtil;
 import de.ellpeck.actuallyadditions.mod.util.StackUtil;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
@@ -28,6 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.EnumPlantType;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 import java.util.Random;
 
@@ -105,8 +105,7 @@ public class BlockPlant extends BlockCrops implements ItemBlockBase.ICustomRarit
                         }
 
                         if(StackUtil.isValid(drop)){
-                            EntityItem entity = new EntityItem(world, pos.getX()+0.5, pos.getY()+0.5, pos.getZ()+0.5, drop);
-                            world.spawnEntity(entity);
+                            ItemHandlerHelper.giveItemToPlayer(player, drop);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1167 

While this may be considered as intended behavior this provides a fix for mods that interact with blocks to harvest them(such as Industrial Foregoing). This is a simple fix with a trade off of unnoticeable gameplay changes.