### PR TITLE
Fix bounding box NPE when placing worm item

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/entity/EntityWorm.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/entity/EntityWorm.java
@@ -21,6 +21,7 @@ import net.minecraft.block.IGrowable;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
@@ -31,7 +32,7 @@ public class EntityWorm extends Entity {
 
     public EntityWorm(World world) {
         super(world);
-        this.setEntityBoundingBox(null);
+        this.setEntityBoundingBox(new AxisAlignedBB(0, 0, 0, 0, 0, 0));
     }
 
     public static boolean canWormify(World world, BlockPos pos, IBlockState state) {


### PR DESCRIPTION
This PR fixes a NPE when placing the Worm item on a valid block. This issue was caused by the `WormEntity`s constructor passing `null` to `Entity#setEntityBoundingBox` which caused an NPE on entity spawn. 

To fix the issue a 0-sized bounding box is passed to the `setEntityBoundingBox` method which prevents players from moving/colliding with the worm entity.

Tested on Mohist `1.12.2-91` before and after fix. Fixes #1332 