### PR TITLE
Fixed Typo in German translation

### DIFF
--- a/src/main/resources/assets/actuallyadditions/lang/de_DE.lang
+++ b/src/main/resources/assets/actuallyadditions/lang/de_DE.lang
@@ -10,7 +10,7 @@ actuallyadditions.cflong=Crystal Flux
 #Fluids
 fluid.actuallyadditions.refinedcanolaoil=Raffiniertes Rapsöl
 fluid.actuallyadditions.canolaoil=Rapsöl
-fluid.actuallyadditions.crystaloil=Krisstalisiertes Öl
+fluid.actuallyadditions.crystaloil=Kristallisiertes Öl
 fluid.actuallyadditions.empoweredoil=Energetisiertes Öl
 
 #Entities


### PR DESCRIPTION
Fixed a Typo in German translation. The word "kristallisiert" derives from the noun "Kristall".