### PR TITLE
iris compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,9 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        url = "https://api.modrinth.com/maven"
+    }
     maven { url = 'https://maven.octo-studios.com/releases' }
 }
 
@@ -110,6 +113,8 @@ dependencies {
 
     localRuntime "curse.maven:jade-324717:5803666"
     localRuntime "curse.maven:mekanism-268560:5680395"
+    localRuntime "maven.modrinth:sodium:mc1.21.1-0.6.0-beta.4-neoforge"
+    localRuntime "curse.maven:irisshaders-455508:5873114"
 
     // Immersive Engineering, mainly for compat datagen
     localRuntime "curse.maven:ie-231951:5828000"

--- a/build.gradle
+++ b/build.gradle
@@ -94,9 +94,6 @@ repositories {
             includeGroup "curse.maven"
         }
     }
-    maven {
-        url = "https://api.modrinth.com/maven"
-    }
     maven { url = 'https://maven.octo-studios.com/releases' }
 }
 
@@ -113,8 +110,6 @@ dependencies {
 
     localRuntime "curse.maven:jade-324717:5803666"
     localRuntime "curse.maven:mekanism-268560:5680395"
-    localRuntime "maven.modrinth:sodium:mc1.21.1-0.6.0-beta.4-neoforge"
-    localRuntime "curse.maven:irisshaders-455508:5873114"
 
     // Immersive Engineering, mainly for compat datagen
     localRuntime "curse.maven:ie-231951:5828000"

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/blocks/render/RenderTypes.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/blocks/render/RenderTypes.java
@@ -25,6 +25,7 @@ public class RenderTypes extends RenderType {
         .setOutputState(MAIN_TARGET)
         .setLightmapState(RenderStateShard.LIGHTMAP)
         .setCullState(RenderStateShard.NO_CULL)
-        .setShaderState(RenderStateShard.POSITION_COLOR_TEX_LIGHTMAP_SHADER)
+        .setShaderState(RenderStateShard.POSITION_COLOR_SHADER)
         .createCompositeState(true));
+
 }

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/particle/ParticleBeam.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/particle/ParticleBeam.java
@@ -37,9 +37,8 @@ public class ParticleBeam extends Particle {
         public BufferBuilder begin(Tesselator tesselator, TextureManager textureManager) {
             RenderSystem.disableCull();
             RenderSystem.enableBlend();
-            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 0.2F);
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
-            return tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
+            return tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
         }
 
         @Override
@@ -101,7 +100,7 @@ public class ParticleBeam extends Particle {
 
         public static ParticleOptions createData(double endX, double endY, double endZ, int color, float alpha,
                                                  int maxAge, double rotationTime, float size) {
-            return new BeamParticleData(endX, endY, endZ, color, maxAge, rotationTime, size);
+            return new BeamParticleData(endX, endY, endZ, FastColor.ARGB32.color((int)(alpha * 255F), color), maxAge, rotationTime, size);
         }
     }
 }

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/particle/ParticleBeam.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/particle/ParticleBeam.java
@@ -37,6 +37,7 @@ public class ParticleBeam extends Particle {
         public BufferBuilder begin(Tesselator tesselator, TextureManager textureManager) {
             RenderSystem.disableCull();
             RenderSystem.enableBlend();
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 0.2F);
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
             return tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
         }

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/util/AssetUtil.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/util/AssetUtil.java
@@ -234,9 +234,9 @@ public final class AssetUtil {
         int g = (color >> 8) & 0xFF;
         int b = color & 0xFF;
         int a = (int) (alpha * 255);*/
-        int r = (int)(((color >> 16) & 0xFF) * alpha);
-        int g = (int)(((color >> 8) & 0xFF) * alpha);
-        int b = (int)((color & 0xFF) * alpha);
+        int r = (int)(((color >> 16) & 0xFF) * alpha * 0.4F);
+        int g = (int)(((color >> 8) & 0xFF) * alpha * 0.4F);
+        int b = (int)((color & 0xFF) * alpha * 0.4F);
         int a = 255;
 
         int lightmap = LightTexture.pack(MAX_LIGHT_X, MAX_LIGHT_Y);
@@ -334,7 +334,7 @@ public final class AssetUtil {
 
         Matrix4f matrix = matrixStack.last().pose();
 
-        RenderSystem.setShader(GameRenderer::getPositionColorLightmapShader);
+        RenderSystem.setShader(GameRenderer::getPositionColorShader);
 
         TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(FORGE_WHITE);
         float minU = sprite.getU0();

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/util/AssetUtil.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/util/AssetUtil.java
@@ -26,7 +26,6 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
@@ -254,35 +253,29 @@ public final class AssetUtil {
 
         Matrix4f matrix = matrixStack.last().pose();
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(FORGE_WHITE);
-        float minU = sprite.getU0();
-        float maxU = sprite.getU1();
-        float minV = sprite.getV0();
-        float maxV = sprite.getV1();
-
         //Draw laser tube faces
         for (int i = 1; i < 4; i++) {
             float width = beamWidth * (i / 4.0f);
             //top
-            builder.addVertex(matrix, -width,  width,    0.0f).setColor(r, g, b, a).setUv(minU, maxV).setLight(lightmap);
-            builder.addVertex(matrix,  width,  width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix,  width,  width, -length).setColor(r, g, b, a).setUv(maxU, minV).setLight(lightmap);
-            builder.addVertex(matrix, -width,  width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix, -width,  width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width,  width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width,  width, -length).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix, -width,  width, -length).setColor(r, g, b, a).setLight(lightmap);
             //bottom
-            builder.addVertex(matrix, -width, -width,    0.0f).setColor(r, g, b, a).setUv(minU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix,  width, -width, -length).setColor(r, g, b, a).setUv(maxU, minV).setLight(lightmap);
-            builder.addVertex(matrix,  width, -width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
+            builder.addVertex(matrix, -width, -width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width, -width, -length).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width, -width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
             //left
-            builder.addVertex(matrix, -width,  width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix, -width,  width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix, -width,  width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix, -width, -width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix, -width,  width, -length).setColor(r, g, b, a).setLight(lightmap);
             //right
-            builder.addVertex(matrix,  width,  width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix,  width, -width,    0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix,  width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix,  width,  width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix,  width,  width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width, -width,    0.0f).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width, -width, -length).setColor(r, g, b, a).setLight(lightmap);
+            builder.addVertex(matrix,  width,  width, -length).setColor(r, g, b, a).setLight(lightmap);
         }
 
 
@@ -336,35 +329,29 @@ public final class AssetUtil {
 
         RenderSystem.setShader(GameRenderer::getPositionColorShader);
 
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(FORGE_WHITE);
-        float minU = sprite.getU0();
-        float maxU = sprite.getU1();
-        float minV = sprite.getV0();
-        float maxV = sprite.getV1();
-
         //Draw laser tube faces
         for (int i = 1; i < 4; i++) {
             float width = beamWidth * (i / 4.0f);
             //top
-            builder.addVertex(matrix, -width, width, 0.0f).setColor(r, g, b, a).setUv(minU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, width, width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, width, width, -length).setColor(r, g, b, a).setUv(maxU, minV).setLight(lightmap);
-            builder.addVertex(matrix, -width, width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix, -width, width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, width, -length).setColor(r, g, b, a);
+            builder.addVertex(matrix, -width, width, -length).setColor(r, g, b, a);
             //bottom
-            builder.addVertex(matrix, -width, -width, 0.0f).setColor(r, g, b, a).setUv(minU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix, width, -width, -length).setColor(r, g, b, a).setUv(maxU, minV).setLight(lightmap);
-            builder.addVertex(matrix, width, -width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
+            builder.addVertex(matrix, -width, -width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, -width, -length).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, -width, 0.0f).setColor(r, g, b, a);
             //left
-            builder.addVertex(matrix, -width, width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix, -width, width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix, -width, width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, -width, -width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, -width, -width, -length).setColor(r, g, b, a);
+            builder.addVertex(matrix, -width, width, -length).setColor(r, g, b, a);
             //right
-            builder.addVertex(matrix, width, width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, width, -width, 0.0f).setColor(r, g, b, a).setUv(maxU, maxV).setLight(lightmap);
-            builder.addVertex(matrix, width, -width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
-            builder.addVertex(matrix, width, width, -length).setColor(r, g, b, a).setUv(minU, minV).setLight(lightmap);
+            builder.addVertex(matrix, width, width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, -width, 0.0f).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, -width, -length).setColor(r, g, b, a);
+            builder.addVertex(matrix, width, width, -length).setColor(r, g, b, a);
             
         }
         matrixStack.popPose();


### PR DESCRIPTION
I basically just threw stuff at rendering code untill something worked. 
Looks like iris doesn't like lightmaps in shaders, so i'm just emulating a similar look with alpha. 

Alternatively different render code can be used when [iris is active](https://github.com/MCRcortex/nvidium/blob/dev/src/main/java/me/cortex/nvidium/sodiumCompat/IrisCheck.java)

Also, I think with some changes the atomic thingie laser can use the basic laser rendering fn instead of particle one, but that's like actual work, so I cba.

before:


![2024-11-05_05 09 15](https://github.com/user-attachments/assets/69821abd-b966-47ee-8ed0-1f7a0e430d65)

![2024-11-05_05 09 25](https://github.com/user-attachments/assets/330e882e-2820-471e-986a-d55c75af1f8f)


after:
![2024-11-05_04 36 27](https://github.com/user-attachments/assets/f72a8273-7389-437a-84c0-82993a72af2a)
![2024-11-05_04 36 19](https://github.com/user-attachments/assets/80a9b0ac-e057-42b3-9f35-166ab488b176)
