### PR TITLE
Config option: disable energy overlay

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/config/CommonConfig.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/config/CommonConfig.java
@@ -89,6 +89,7 @@ public class CommonConfig {
     }
 
     public static class Other {
+        public static ModConfigSpec.BooleanValue HIDE_ENERGY_OVERLAY;
         public static ModConfigSpec.BooleanValue SOLID_XP_ALWAYS_ORBS;
         public static ModConfigSpec.BooleanValue DO_UPDATE_CHECK;
         public static ModConfigSpec.BooleanValue UPDATE_CHECK_VERSION_SPECIFIC;
@@ -115,6 +116,9 @@ public class CommonConfig {
         public static void build() {
 
             BUILDER.comment("Everything else").push("other");
+
+            HIDE_ENERGY_OVERLAY = BUILDER.comment("If true, when looking at blocks the Energy Overlay will be hidden.")
+                .define("hideEnergyOverlay", false);
 
             SOLID_XP_ALWAYS_ORBS = BUILDER.comment("If true, Solidified Experience will always spawn orbs, even for regular players.")
                 .define("solidXPOrbs", false);

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/event/ClientEvents.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/event/ClientEvents.java
@@ -60,6 +60,8 @@ public class ClientEvents {
 
     private static EnergyDisplay energyDisplay;
 
+    boolean shouldHideEnergyOverlay = CommonConfig.Other.HIDE_ENERGY_OVERLAY.get();
+
     // TODO: [port] the fuck?
     @SubscribeEvent
     public void onClientTick(ClientTickEvent.Post event) {
@@ -264,7 +266,7 @@ public class ClientEvents {
                     }
                 }
 
-                if (tileHit instanceof IEnergyDisplay display) {
+                if (tileHit instanceof IEnergyDisplay display && !shouldHideEnergyOverlay) {
                     if (!display.needsHoldShift() || player.isShiftKeyDown()) {
                         if (energyDisplay == null) {
                             energyDisplay = new EnergyDisplay(0, 0, null);

--- a/src/main/java/de/ellpeck/actuallyadditions/mod/event/ClientEvents.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/event/ClientEvents.java
@@ -60,8 +60,6 @@ public class ClientEvents {
 
     private static EnergyDisplay energyDisplay;
 
-    boolean shouldHideEnergyOverlay = CommonConfig.Other.HIDE_ENERGY_OVERLAY.get();
-
     // TODO: [port] the fuck?
     @SubscribeEvent
     public void onClientTick(ClientTickEvent.Post event) {
@@ -266,7 +264,7 @@ public class ClientEvents {
                     }
                 }
 
-                if (tileHit instanceof IEnergyDisplay display && !shouldHideEnergyOverlay) {
+                if (tileHit instanceof IEnergyDisplay display && !CommonConfig.Other.HIDE_ENERGY_OVERLAY.get()) {
                     if (!display.needsHoldShift() || player.isShiftKeyDown()) {
                         if (energyDisplay == null) {
                             energyDisplay = new EnergyDisplay(0, 0, null);


### PR DESCRIPTION
An option to hide energy overlay, visible by default.

My monke brain doesn't like looking at the same stuff twice with jade / other waila fork.
