### PR TITLE
Get NBT enchant levels instead of potentially event-modified levels

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/items/lens/LensDisenchanting.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/items/lens/LensDisenchanting.java
@@ -53,7 +53,7 @@ public class LensDisenchanting extends Lens {
                                     return false;
                                 }
                             } else {
-                                ItemEnchantments enchants = stack.getAllEnchantments(tile.getWorldObject().registryAccess().lookupOrThrow(Registries.ENCHANTMENT));
+                                ItemEnchantments enchants = stack.getTagEnchantments();
                                 if (!enchants.isEmpty()) {
                                     if (toDisenchant == null) {
                                         toDisenchant = item;
@@ -70,7 +70,7 @@ public class LensDisenchanting extends Lens {
                     ItemStack disenchantStack = toDisenchant.getItem();
                     ItemStack bookStack = book.getItem();
 
-                    ItemEnchantments enchants = disenchantStack.getAllEnchantments(tile.getWorldObject().registryAccess().lookupOrThrow(Registries.ENCHANTMENT));
+                    ItemEnchantments enchants = disenchantStack.getTagEnchantments();
                     if (!enchants.isEmpty()) {
                         Holder<Enchantment> enchant = enchants.keySet().iterator().next();
                         int level = enchants.getLevel(enchant);


### PR DESCRIPTION
Currently, the disenchanting lens uses `ItemStack#getAllEnchantments`, which may not be accurate to the NBT level (due to potential modification from `GetEnchantmentLevelEvent`).

This PR swaps it over to `ItemStack#getTagEnchantments` instead, as it ignores the event.