### PR TITLE
Make the Reconstructor in LaserRecipeCategory render only

### DIFF
--- a/src/main/java/de/ellpeck/actuallyadditions/mod/jei/laser/LaserRecipeCategory.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/mod/jei/laser/LaserRecipeCategory.java
@@ -66,7 +66,7 @@ public class LaserRecipeCategory implements IRecipeCategory<LaserRecipe> {
         HolderLookup.Provider registries = level.registryAccess();
 
         builder.addSlot(RecipeIngredientRole.INPUT, 5, 19).addIngredients(recipe.getInput());
-        builder.addSlot(RecipeIngredientRole.INPUT, 35, 20).addItemStack(RECONSTRUCTOR);
+        builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 35, 20).addItemStack(RECONSTRUCTOR);
 
         builder.addSlot(RecipeIngredientRole.OUTPUT, 66, 19).addItemStack(recipe.getResultItem(registries));
     }


### PR DESCRIPTION
This fixes an issue I noticed where, when using EMI and its recipe tree, it would also assume that Atomic Reconstructors are required ingredients and, as such, the recipe would look infinitely more expensive than it is. I didn't like that, so...

Before:
![image](https://github.com/user-attachments/assets/dc145b69-39bc-4ba6-a3e3-ff8a6d2f95df)
After:
![image](https://github.com/user-attachments/assets/81a23fd9-0aef-4374-ada3-e6eed12ad317)
