### PR TITLE
Add recipe for Smooth Black Quartz Block

### DIFF
--- a/src/generated/resources/.cache/9fb1092f32d4fcbf9e061ffd718d4ec689c6c95e
+++ b/src/generated/resources/.cache/9fb1092f32d4fcbf9e061ffd718d4ec689c6c95e
@@ -1,4 +1,4 @@
-// 1.21.1	2025-03-21T11:30:42.3162467	Recipes
+// 1.21.1	2025-10-06T15:29:55.265298	Recipes
 29b83e4143e1081257ba78ef24485b64dc8515cd data/actuallyadditions/advancement/recipes/misc/lamp_controller.json
 b44fee42c2b2b3f56256fe76b2d9f529dc87350a data/actuallyadditions/recipe/atomic_reconstructor.json
 b1c937b75ba7f8e02dfac4db5253271f2de502e5 data/actuallyadditions/recipe/battery_box.json
@@ -106,6 +106,7 @@ c2ac056a53acebbe002bae1edf2cb81175eebaa6 data/actuallyadditions/recipe/placer.js
 6209355d9f0af0944e04dd940b94d1e7842bcf6a data/actuallyadditions/recipe/powered_furnace.json
 81009abd0f659d5bde626a430509cb501b6c0ffd data/actuallyadditions/recipe/ranged_collector.json
 b267b3df7e751818fadbbba4015706bc50c95c6a data/actuallyadditions/recipe/shock_suppressor.json
+c1b269b7c5352c5408d86e2b327eefaf87e8d617 data/actuallyadditions/recipe/smooth_black_quartz_block_from_smelting.json
 c26cc551ceec989b7dd12487b44ed7742e74652d data/actuallyadditions/recipe/smooth_black_quartz_slab.json
 4c5f44cd416a366b2ea5f1e3ee22dcaa7daa41c7 data/actuallyadditions/recipe/smooth_black_quartz_slab_from_smooth_black_quartz_block_stonecutting.json
 b1f018cb6f81d30659409c08f46f9e30a9c4e38f data/actuallyadditions/recipe/smooth_black_quartz_stair.json

--- a/src/generated/resources/data/actuallyadditions/recipe/smooth_black_quartz_block_from_smelting.json
+++ b/src/generated/resources/data/actuallyadditions/recipe/smooth_black_quartz_block_from_smelting.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "cookingtime": 200,
+  "experience": 0.1,
+  "ingredient": {
+    "item": "actuallyadditions:black_quartz_block"
+  },
+  "result": {
+    "count": 1,
+    "id": "actuallyadditions:smooth_black_quartz_block"
+  }
+}

--- a/src/main/java/de/ellpeck/actuallyadditions/data/BlockRecipeGenerator.java
+++ b/src/main/java/de/ellpeck/actuallyadditions/data/BlockRecipeGenerator.java
@@ -104,6 +104,9 @@ public class BlockRecipeGenerator extends RecipeProvider {
         Recipe.stonecutterResultFromBase(recipeOutput, RecipeCategory.DECORATIONS, ActuallyBlocks.BLACK_QUARTZ_BRICK.getItem(), ActuallyBlocks.BLACK_QUARTZ.get());
         Recipe.stonecutterResultFromBase(recipeOutput, RecipeCategory.DECORATIONS, ActuallyBlocks.CHISELED_BLACK_QUARTZ.getItem(), ActuallyBlocks.BLACK_QUARTZ.get());
 
+        // Smooth Black Quartz Smelting
+        Recipe.smeltingResultFromBase(recipeOutput, RecipeCategory.DECORATIONS, ActuallyBlocks.SMOOTH_BLACK_QUARTZ.get(), ActuallyBlocks.BLACK_QUARTZ.get());
+
         //Black Quartz Wall
         Recipe.wall(ActuallyBlocks.BLACK_QUARTZ_WALL.getItem(), ActuallyBlocks.BLACK_QUARTZ.get(), recipeOutput);
         Recipe.stonecutterResultFromBase(recipeOutput, RecipeCategory.DECORATIONS, ActuallyBlocks.BLACK_QUARTZ_WALL.getItem(), ActuallyBlocks.BLACK_QUARTZ.get());
@@ -616,6 +619,12 @@ public class BlockRecipeGenerator extends RecipeProvider {
             SingleItemRecipeBuilder.stonecutting(Ingredient.of(material), category, result, resultCount)
                     .unlockedBy(getHasName(material), has(material))
                     .save(recipeOutput, ActuallyAdditions.modLoc(getConversionRecipeName(result, material) + "_stonecutting"));
+        }
+
+        protected static void smeltingResultFromBase(RecipeOutput recipeOutput, RecipeCategory category, ItemLike result, ItemLike material) {
+            SimpleCookingRecipeBuilder.smelting(Ingredient.of(material), category, result, 0.1F, 200)
+                    .unlockedBy(getHasName(material), has(material))
+                    .save(recipeOutput, ActuallyAdditions.modLoc(getSmeltingRecipeName(result)));
         }
 
         private static class Shapeless extends ShapelessRecipeBuilder {

--- a/src/main/resources/data/actuallyadditions/recipe/compat/mekanism/smooth_black_quartz_block_from_crushing.json
+++ b/src/main/resources/data/actuallyadditions/recipe/compat/mekanism/smooth_black_quartz_block_from_crushing.json
@@ -1,0 +1,11 @@
+{
+  "type": "mekanism:crushing",
+  "input": {
+    "count": 1,
+    "item": "actuallyadditions:black_quartz_block"
+  },
+  "output": {
+    "count": 1,
+    "id": "actuallyadditions:smooth_black_quartz_block"
+  }
+}


### PR DESCRIPTION
This change adds Smelting and Mekanism Crushing recipes for the Black Quartz Block, allowing it to be turned into Smooth Black Quartz again.
Fixes #1491 